### PR TITLE
Test/Refactor: split out adobe line splitting logic, added unit tests

### DIFF
--- a/client/src/components/bullets/utils.ts
+++ b/client/src/components/bullets/utils.ts
@@ -14,6 +14,13 @@ export const hashCode = (str: string): number => {
     return hash
 }
 
+  // Regex- split after one of the following: \u2004 \u2009 \u2006 \s ? / | - % !
+    // but ONLY if immediately followed by: [a-zA-z] [0-9] + \
+    export const adobeLineSplitFn = (text: string)=>{
+        const regex = /([\u2004\u2009\u2006\s?/|\-%!])(?=[a-zA-Z0-9+\\])/
+        return text.split(regex).filter(Boolean);
+      }
+
 export const getRandomInt = (seed: string, max: number): number => {
     return Math.floor(Math.abs((Math.floor(9 * hashCode(seed) + 5) % 100000) / 100000) * Math.floor(max))
 }
@@ -153,7 +160,7 @@ export const renderBulletText = (text: string, getWidth: (str: string) => number
 
         // Regex- split after one of the following: \u2004 \u2009 \u2006 \s ? / | - % !
         // but ONLY if immediately followed by: [a-zA-z] [0-9] + \
-        const textSplit = text.split(/(?<=[\u2004\u2009\u2006\s?/|\-%!])(?=[a-zA-Z0-9+\\])/)
+        const textSplit = adobeLineSplitFn(text); 
 
         // check to make sure the first token is smaller than the desired width.
         //   This is usually true, unless the desired width is abnormally small, or the

--- a/client/tests/components/bullets/utils.test.ts
+++ b/client/tests/components/bullets/utils.test.ts
@@ -1,4 +1,4 @@
-import { hashCode, optimize, renderBulletText, Results } from '../../../src/components/bullets/utils'
+import { hashCode, optimize, renderBulletText, Results, tokenize, adobeLineSplitFn } from '../../../src/components/bullets/utils'
 import { STATUS } from '../../../src/const/const'
 
 describe('hashCode', () => {
@@ -122,6 +122,119 @@ describe('optimize', () => {
         expect(mockEvalFcn).toHaveBeenCalledTimes(3)
         expect(actualResults).toEqual(expectedResults)
     })
+})
+
+describe('tokenization tests', () => {
+    test("should split sentence into several pieces", () => {
+        const text = "hello world hello world";
+        const results = ["hello", "world", "hello", "world"];
+        expect(tokenize(text)).toEqual(results);
+    });
+
+    test("should split sentence into several pieces even if there are several spaces", () => {
+        const text = "hello   world      hello  world";
+        const results = ["hello", "world", "hello", "world"];
+        expect(tokenize(text)).toEqual(results);
+    });
+
+    test("should split sentence into several pieces even if there unicode type spaces", () => {
+        const text = "hello\u2004world\u2006hello\u2009world";
+        const results = ["hello", "world", "hello", "world"];
+        expect(tokenize(text)).toEqual(results);
+    });
+
+    test("should split sentence into several pieces even if there mixed unicode type spaces", () => {
+        const text = "hello\u2004\u2009 world \u2006\u2009hello \u2009world";
+        const results = ["hello", "world", "hello", "world"];
+        expect(tokenize(text)).toEqual(results);
+    });
+
+})
+
+describe("adobe line splitting tests", () => {
+    test("Regex test: should split after one of the following: \u2004 \u2009 \u2006 \s ? / | - % ! " +
+        "but ONLY if immediately followed by: [a-zA-z] [0-9] + \ ", () => {
+
+            const splitFn = (text: string) => adobeLineSplitFn(text);
+
+            const tests = [
+                { test: '\u2004\u2004', ans: ['\u2004\u2004'] },
+                { test: '\u2004 ', ans: ['\u2004 '] },
+                { test: '\u2004.', ans: ['\u2004.'] },
+                { test: '\u2004a', ans: ['\u2004', 'a'] },
+                { test: '\u2004A', ans: ['\u2004', 'A'] },
+                { test: '\u20049', ans: ['\u2004', '9'] },
+                { test: '\u2004+', ans: ['\u2004', '+'] },
+                { test: '\u2004\\', ans: ['\u2004', '\\'] },
+
+                { test: ' \u2004', ans: [' \u2004'] },
+                { test: '  ', ans: ['  '] },
+                { test: ' .', ans: [' .'] },
+                { test: ' a', ans: [' ', 'a'] },
+                { test: ' A', ans: [' ', 'A'] },
+                { test: ' 9', ans: [' ', '9'] },
+                { test: ' +', ans: [' ', '+'] },
+                { test: ' \\', ans: [' ', '\\'] },
+
+                { test: '?\u2004', ans: ['?\u2004'] },
+                { test: '? ', ans: ['? '] },
+                { test: '?.', ans: ['?.'] },
+                { test: '?a', ans: ['?', 'a'] },
+                { test: '?A', ans: ['?', 'A'] },
+                { test: '?9', ans: ['?', '9'] },
+                { test: '?+', ans: ['?', '+'] },
+                { test: '?\\', ans: ['?', '\\'] },
+
+                { test: '/\u2004', ans: ['/\u2004'] },
+                { test: '/ ', ans: ['/ '] },
+                { test: '/.', ans: ['/.'] },
+                { test: '/a', ans: ['/', 'a'] },
+                { test: '/A', ans: ['/', 'A'] },
+                { test: '/9', ans: ['/', '9'] },
+                { test: '/+', ans: ['/', '+'] },
+                { test: '/\\', ans: ['/', '\\'] },
+
+                { test: '|\u2004', ans: ['|\u2004'] },
+                { test: '| ', ans: ['| '] },
+                { test: '|.', ans: ['|.'] },
+                { test: '|a', ans: ['|', 'a'] },
+                { test: '|A', ans: ['|', 'A'] },
+                { test: '|9', ans: ['|', '9'] },
+                { test: '|+', ans: ['|', '+'] },
+                { test: '|\\', ans: ['|', '\\'] },
+
+                { test: '-\u2004', ans: ['-\u2004'] },
+                { test: '- ', ans: ['- '] },
+                { test: '-.', ans: ['-.'] },
+                { test: '-a', ans: ['-', 'a'] },
+                { test: '-A', ans: ['-', 'A'] },
+                { test: '-9', ans: ['-', '9'] },
+                { test: '-+', ans: ['-', '+'] },
+                { test: '-\\', ans: ['-', '\\'] },
+
+                { test: '%\u2004', ans: ['%\u2004'] },
+                { test: '% ', ans: ['% '] },
+                { test: '%.', ans: ['%.'] },
+                { test: '%a', ans: ['%', 'a'] },
+                { test: '%A', ans: ['%', 'A'] },
+                { test: '%9', ans: ['%', '9'] },
+                { test: '%+', ans: ['%', '+'] },
+                { test: '%\\', ans: ['%', '\\'] },
+
+                { test: '!\u2004', ans: ['!\u2004'] },
+                { test: '! ', ans: ['! '] },
+                { test: '!.', ans: ['!.'] },
+                { test: '!a', ans: ['!', 'a'] },
+                { test: '!A', ans: ['!', 'A'] },
+                { test: '!9', ans: ['!', '9'] },
+                { test: '!+', ans: ['!', '+'] },
+                { test: '!\\', ans: ['!', '\\'] },
+
+            ]
+
+            tests.forEach(({ test, ans }) => expect(splitFn(test)).toEqual(ans));
+
+        });
 })
 
 describe('renderBulletText', () => {


### PR DESCRIPTION
## adobe line splitting

in general for text entry, when you have too many words on a single line, the text editor has to decide how and where to break up overflowing words to transition them to the next line. For most words, the editor will just take the last word that doesn't fit and move it over to the next line. However, what should be done in weird cases like `hello/world` or `hello?world` ? Should it treat the whole phrase as a single word, or break on the character in between? That is going to depend on the editor, and I found that the browser's text input field and the adobe forms text input fields made different decisions on when to split words to fit into lines better. In order to make sure this is correct, I split out the line break logic into its own function and put in several unit tests against it. 

## tokenize unit tests

`tokenize` just takes a bullet and splits it into an array based on whitespace. I wasn't sure if the `\s` regex character class also handled unicode half-space and other special whitespace characters, so I added unit tests to ensure that it did work.